### PR TITLE
Fix header menu not opening on mobile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,4 @@ $RECYCLE.BIN/
 / LibVisWeb/.vs/LibVisWeb/v15/Server/sqlite3/storage.ide-wal
 / LibVisWeb/LibVisWeb.sln
 / LibVisWeb/LibVisWeb/appsettings.json
+/LibVisWeb/.vs

--- a/LibVisWeb/LibVisWeb/ClientApp/components/header/Header.tsx
+++ b/LibVisWeb/LibVisWeb/ClientApp/components/header/Header.tsx
@@ -31,13 +31,19 @@ class Header extends React.Component<HeaderProps, {}> {
                 <div className="tda-container-half-yellow tda-container-size">
                     <div className="td-container td-header-row tda-header-row-yellow tda-container-size">
                         <div className="tda-header-chess-pattern tda-container-size">    
-                                                        
-                            <HeaderTop />
-
-                            <HeaderLogo />
-
-                            <HeaderMenu />
-
+                            <div>
+                                <div className="col-lg-12">
+                                    <HeaderTop />
+                                </div>
+                                <div className="row">
+                                    <div className="col-lg-12">
+                                        <HeaderLogo />
+                                    </div>
+                                    <div className="col-lg-12">
+                                        <HeaderMenu />
+                                    </div>
+                                </div>
+                            </div>
                         </div>
                     </div>
                 </div>

--- a/LibVisWeb/LibVisWeb/ClientApp/css/site.css
+++ b/LibVisWeb/LibVisWeb/ClientApp/css/site.css
@@ -342,7 +342,7 @@
 }
 
 .mobile-menu-body {
-    position: absolute;
+    position: fixed;
     background-color: #000;
     color: #ffcc00;
     top: 100px;


### PR DESCRIPTION
#3 

Solução proposta:
* Colocar os componentes HeaderLogo e HeaderMenu dentro de uma estrutura row -> col. Isso é necessário por que no mobile é esperado que estes dois compoentes fiquem na mesma linha
* Modificar a position do menu mobile para fixed para que ele apareça mais próximo do botão

Proposed solutionÇ
* Wrap HeaderLogo and HeaderMenu inside a row -> col structure. This is needed because on mobile it's expected that these two components share the same line
* Modify the position of the mobile menu to relative so it appears closer to the button